### PR TITLE
Fix variable naming conflict in create_token function

### DIFF
--- a/api-server/app/auth/controllers/create_token.py
+++ b/api-server/app/auth/controllers/create_token.py
@@ -55,9 +55,9 @@ async def create_token(request: TokenRequest, x_exosphere_request_id: str) -> To
             if project.super_admin.ref.id == user.id:
                 previlage = "super_admin"
 
-            for user in project.users:
-                if user.user.ref.id == user.id:
-                    previlage = user.permission.value
+            for project_user in project.users:
+                if project_user.user.ref.id == user.id:
+                    previlage = project_user.permission.value
                     break
 
             if not previlage:


### PR DESCRIPTION
## Description
This PR fixes the variable naming conflict in the `create_token()` function where `user` was being used for both the authenticated user and the loop variable.

## Change Made
- Renamed loop variable from `user` to `project_user` to avoid shadowing the authenticated user

## Related Issue
Fixes #58
